### PR TITLE
Add FHIR Bundle export to Records tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Xcode
 xcuserdata/
+xcshareddata/
 build/
 DerivedData/
 

--- a/FHIR-HOSE/View/RecordsListView.swift
+++ b/FHIR-HOSE/View/RecordsListView.swift
@@ -6,11 +6,25 @@
 //
 
 import SwiftUI
+#if os(iOS) || os(visionOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 struct RecordsListView: View {
     @ObservedObject var recordStore: HealthRecordStore
     @State private var searchText = ""
-    
+
+    @State private var exportURL: URL?
+    @State private var exportErrorMessage: String?
+    @State private var copyConfirmation: String?
+    @State private var isExporting = false
+    @State private var bannerDismissTask: Task<Void, Never>?
+
+    private static let bannerVisibleDuration: Duration = .seconds(2.5)
+    private static let bannerFadeDuration: Double = 0.35
+
     var body: some View {
         Group {
             if recordStore.isLoadingHealthKitData && recordStore.records.isEmpty {
@@ -33,7 +47,7 @@ struct RecordsListView: View {
                         }
                         .padding(.vertical, 8)
                     }
-                    
+
                     ForEach(filteredRecords) { record in
                         NavigationLink(destination: RecordDetailView(record: record)) {
                             RecordRowView(record: record)
@@ -47,13 +61,49 @@ struct RecordsListView: View {
                 }
             }
         }
-        .overlay(alignment: .bottom) {
-            if !recordStore.records.isEmpty {
-                recordCountView
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Button(action: copyBundleToClipboard) {
+                        Label("Copy FHIR Bundle to Clipboard", systemImage: "doc.on.doc")
+                    }
+                    Button(action: exportBundleToFile) {
+                        Label("Save FHIR Bundle to File…", systemImage: "square.and.arrow.down")
+                    }
+                    if let url = exportURL {
+                        ShareLink(item: url) {
+                            Label("Share \(url.lastPathComponent)", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                } label: {
+                    if isExporting {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+                .disabled(isExporting || recordStore.records.isEmpty)
             }
         }
+        .overlay(alignment: .bottom) {
+            VStack(spacing: 4) {
+                if let copyConfirmation {
+                    bannerText(copyConfirmation, color: .green)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
+                if let exportErrorMessage {
+                    bannerText(exportErrorMessage, color: .red)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
+                if !recordStore.records.isEmpty {
+                    recordCountView
+                }
+            }
+            .animation(.easeOut(duration: Self.bannerFadeDuration), value: copyConfirmation)
+            .animation(.easeOut(duration: Self.bannerFadeDuration), value: exportErrorMessage)
+        }
     }
-    
+
     private var filteredRecords: [HealthRecord] {
         if searchText.isEmpty {
             return recordStore.records
@@ -65,7 +115,7 @@ struct RecordsListView: View {
             }
         }
     }
-    
+
     private var recordCountView: some View {
         Text("\(filteredRecords.count) records")
             .font(.caption)
@@ -75,5 +125,96 @@ struct RecordsListView: View {
             .background(Color(UIColor.systemBackground).opacity(0.8))
             .cornerRadius(8)
             .padding(.bottom, 8)
+    }
+
+    private func bannerText(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(color.opacity(0.9))
+            .cornerRadius(8)
+    }
+
+    private func copyBundleToClipboard() {
+        clearBanners()
+        do {
+            let data = try FHIRBundleExporter.makeCollectionBundleData(from: recordStore.records)
+            guard let json = String(data: data, encoding: .utf8) else {
+                showError("Could not encode bundle as UTF-8.")
+                return
+            }
+            writeStringToClipboard(json)
+            let kb = Double(data.count) / 1024.0
+            showBanner(success: String(format: "Copied %.1f KB FHIR Bundle to clipboard.", kb))
+        } catch {
+            showError("Copy failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func exportBundleToFile() {
+        isExporting = true
+        clearBanners()
+        let records = recordStore.records
+
+        Task.detached(priority: .userInitiated) {
+            do {
+                let data = try FHIRBundleExporter.makeCollectionBundleData(from: records)
+                let timestamp = ISO8601DateFormatter().string(from: Date())
+                    .replacingOccurrences(of: ":", with: "-")
+                let url = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("fhir-bundle-\(timestamp).json")
+                try data.write(to: url, options: .atomic)
+
+                await MainActor.run {
+                    exportURL = url
+                    isExporting = false
+                }
+            } catch {
+                await MainActor.run {
+                    isExporting = false
+                    showError("Export failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func clearBanners() {
+        bannerDismissTask?.cancel()
+        bannerDismissTask = nil
+        copyConfirmation = nil
+        exportErrorMessage = nil
+    }
+
+    private func showBanner(success: String) {
+        copyConfirmation = success
+        exportErrorMessage = nil
+        scheduleBannerDismiss()
+    }
+
+    private func showError(_ message: String) {
+        exportErrorMessage = message
+        copyConfirmation = nil
+        scheduleBannerDismiss()
+    }
+
+    private func scheduleBannerDismiss() {
+        bannerDismissTask?.cancel()
+        bannerDismissTask = Task { @MainActor in
+            try? await Task.sleep(for: Self.bannerVisibleDuration)
+            guard !Task.isCancelled else { return }
+            copyConfirmation = nil
+            exportErrorMessage = nil
+        }
+    }
+
+    private func writeStringToClipboard(_ string: String) {
+        #if os(iOS) || os(visionOS)
+        UIPasteboard.general.string = string
+        #elseif os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+        #endif
     }
 }

--- a/FHIR-HOSE/ViewModel/FHIRBundleExporter.swift
+++ b/FHIR-HOSE/ViewModel/FHIRBundleExporter.swift
@@ -1,0 +1,67 @@
+//
+//  FHIRBundleExporter.swift
+//  FHIR-HOSE
+//
+
+import Foundation
+
+/// Assembles every record's FHIR JSON into a single FHIR R4 `collection` Bundle,
+/// suitable for handing to downstream consumers that expect a Bundle envelope.
+///
+/// - Charmonizer-produced records contribute their `fhirData` (a Patient resource).
+/// - HealthKit-sourced records contribute the base64-encoded JSON stored under
+///   `healthKitData["fhirResource"]`. When that payload is itself a Bundle, its
+///   entries are flattened into the output Bundle.
+enum FHIRBundleExporter {
+
+    static func makeCollectionBundle(from records: [HealthRecord]) -> [String: Any] {
+        var entries: [[String: Any]] = []
+
+        for record in records {
+            if let resource = record.fhirData {
+                appendResource(resource, to: &entries)
+                continue
+            }
+
+            if let b64 = record.healthKitData?["fhirResource"] as? String,
+               !b64.isEmpty,
+               let raw = Data(base64Encoded: b64),
+               let resource = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] {
+                appendResource(resource, to: &entries)
+            }
+        }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+
+        let bundle: [String: Any] = [
+            "resourceType": "Bundle",
+            "type": "collection",
+            "timestamp": iso.string(from: Date()),
+            "entry": entries
+        ]
+        return bundle
+    }
+
+    static func makeCollectionBundleData(from records: [HealthRecord]) throws -> Data {
+        let bundle = makeCollectionBundle(from: records)
+        return try JSONSerialization.data(
+            withJSONObject: bundle,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    private static func appendResource(_ resource: [String: Any], to entries: inout [[String: Any]]) {
+        if (resource["resourceType"] as? String) == "Bundle",
+           let inner = resource["entry"] as? [[String: Any]] {
+            for innerEntry in inner {
+                if let innerResource = innerEntry["resource"] as? [String: Any] {
+                    entries.append(["resource": innerResource])
+                }
+            }
+            return
+        }
+
+        entries.append(["resource": resource])
+    }
+}


### PR DESCRIPTION
Adds an Export menu to the Records toolbar with Copy to Clipboard, Save to File, and Share actions. A new `FHIRBundleExporter` assembles every loaded record into a single FHIR R4 `collection` Bundle.

Also gitignores `xcshareddata/`.