### PR TITLE
Split FHIR Bundle export by version, add ZIP, redesign export button

### DIFF
--- a/FHIR-HOSE/View/RecordsListView.swift
+++ b/FHIR-HOSE/View/RecordsListView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 #if os(iOS) || os(visionOS)
 import UIKit
 #elseif os(macOS)
@@ -15,15 +16,6 @@ import AppKit
 struct RecordsListView: View {
     @ObservedObject var recordStore: HealthRecordStore
     @State private var searchText = ""
-
-    @State private var exportURL: URL?
-    @State private var exportErrorMessage: String?
-    @State private var copyConfirmation: String?
-    @State private var isExporting = false
-    @State private var bannerDismissTask: Task<Void, Never>?
-
-    private static let bannerVisibleDuration: Duration = .seconds(2.5)
-    private static let bannerFadeDuration: Double = 0.35
 
     var body: some View {
         Group {
@@ -61,47 +53,66 @@ struct RecordsListView: View {
                 }
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Menu {
-                    Button(action: copyBundleToClipboard) {
-                        Label("Copy FHIR Bundle to Clipboard", systemImage: "doc.on.doc")
-                    }
-                    Button(action: exportBundleToFile) {
-                        Label("Save FHIR Bundle to File…", systemImage: "square.and.arrow.down")
-                    }
-                    if let url = exportURL {
-                        ShareLink(item: url) {
-                            Label("Share \(url.lastPathComponent)", systemImage: "square.and.arrow.up")
-                        }
-                    }
-                } label: {
-                    if isExporting {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "square.and.arrow.up")
-                    }
-                }
-                .disabled(isExporting || recordStore.records.isEmpty)
+        .safeAreaInset(edge: .bottom) {
+            if !recordStore.records.isEmpty {
+                bottomActionBar
             }
         }
-        .overlay(alignment: .bottom) {
-            VStack(spacing: 4) {
-                if let copyConfirmation {
-                    bannerText(copyConfirmation, color: .green)
-                        .transition(.opacity.combined(with: .move(edge: .bottom)))
-                }
-                if let exportErrorMessage {
-                    bannerText(exportErrorMessage, color: .red)
-                        .transition(.opacity.combined(with: .move(edge: .bottom)))
-                }
-                if !recordStore.records.isEmpty {
-                    recordCountView
-                }
+    }
+
+    private var bottomActionBar: some View {
+        shareControl
+            .padding(.horizontal, 16)
+            .padding(.bottom, 4)
+    }
+
+    @ViewBuilder
+    private var shareControl: some View {
+        let exports = FHIRBundleExporter.makeExports(from: recordStore.records)
+
+        if exports.count == 1 {
+            // Single release: skip the menu — one tap goes straight to the share sheet.
+            ShareLink(
+                item: BundleFile(export: exports[0]),
+                preview: SharePreview("\(exports[0].displayName) FHIR Bundle")
+            ) {
+                shareButtonLabel("Export Health Data")
             }
-            .animation(.easeOut(duration: Self.bannerFadeDuration), value: copyConfirmation)
-            .animation(.easeOut(duration: Self.bannerFadeDuration), value: exportErrorMessage)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        } else if exports.count > 1 {
+            Menu {
+                ForEach(exports, id: \.release) { export in
+                    ShareLink(
+                        item: BundleFile(export: export),
+                        preview: SharePreview("\(export.displayName) FHIR Bundle")
+                    ) {
+                        Label(
+                            "\(export.displayName) (\(export.entryCount) records)",
+                            systemImage: "doc.text"
+                        )
+                    }
+                }
+                Divider()
+                ShareLink(
+                    item: BundlesZipFile(exports: exports),
+                    preview: SharePreview("FHIR Bundles ZIP")
+                ) {
+                    Label("All as ZIP", systemImage: "doc.zipper")
+                }
+            } label: {
+                shareButtonLabel("Export Health Data")
+            }
+            .menuStyle(.button)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
         }
+    }
+
+    private func shareButtonLabel(_ title: String) -> some View {
+        Label(title, systemImage: "square.and.arrow.up")
+            .fontWeight(.semibold)
+            .frame(maxWidth: .infinity)
     }
 
     private var filteredRecords: [HealthRecord] {
@@ -115,106 +126,47 @@ struct RecordsListView: View {
             }
         }
     }
+}
 
-    private var recordCountView: some View {
-        Text("\(filteredRecords.count) records")
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Color(UIColor.systemBackground).opacity(0.8))
-            .cornerRadius(8)
-            .padding(.bottom, 8)
+// MARK: - Transferable share items
+
+/// A single FHIR Bundle file produced on-demand for `ShareLink`. The JSON is only
+/// serialized and written to `tmp/` when the share sheet actually requests it.
+private struct BundleFile: Transferable {
+    let export: FHIRBundleExporter.Export
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .json) { file in
+            let data = try file.export.data()
+            let timestamp = ISO8601DateFormatter().string(from: Date())
+                .replacingOccurrences(of: ":", with: "-")
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("fhir-bundle-\(file.export.release)-\(timestamp).json")
+            try data.write(to: url, options: .atomic)
+            return SentTransferredFile(url)
+        }
     }
+}
 
-    private func bannerText(_ text: String, color: Color) -> some View {
-        Text(text)
-            .font(.caption)
-            .foregroundColor(.white)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(color.opacity(0.9))
-            .cornerRadius(8)
-    }
+/// A zip of one-or-more FHIR Bundles, generated on-demand for `ShareLink`.
+private struct BundlesZipFile: Transferable {
+    let exports: [FHIRBundleExporter.Export]
 
-    private func copyBundleToClipboard() {
-        clearBanners()
-        do {
-            let data = try FHIRBundleExporter.makeCollectionBundleData(from: recordStore.records)
-            guard let json = String(data: data, encoding: .utf8) else {
-                showError("Could not encode bundle as UTF-8.")
-                return
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .zip) { file in
+            let timestamp = ISO8601DateFormatter().string(from: Date())
+                .replacingOccurrences(of: ":", with: "-")
+            let entries: [ZipEncoder.File] = try file.exports.map { export in
+                ZipEncoder.File(
+                    name: "fhir-bundle-\(export.release)-\(timestamp).json",
+                    data: try export.data()
+                )
             }
-            writeStringToClipboard(json)
-            let kb = Double(data.count) / 1024.0
-            showBanner(success: String(format: "Copied %.1f KB FHIR Bundle to clipboard.", kb))
-        } catch {
-            showError("Copy failed: \(error.localizedDescription)")
+            let archive = ZipEncoder.makeArchive(files: entries)
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("fhir-bundles-\(timestamp).zip")
+            try archive.write(to: url, options: .atomic)
+            return SentTransferredFile(url)
         }
-    }
-
-    private func exportBundleToFile() {
-        isExporting = true
-        clearBanners()
-        let records = recordStore.records
-
-        Task.detached(priority: .userInitiated) {
-            do {
-                let data = try FHIRBundleExporter.makeCollectionBundleData(from: records)
-                let timestamp = ISO8601DateFormatter().string(from: Date())
-                    .replacingOccurrences(of: ":", with: "-")
-                let url = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("fhir-bundle-\(timestamp).json")
-                try data.write(to: url, options: .atomic)
-
-                await MainActor.run {
-                    exportURL = url
-                    isExporting = false
-                }
-            } catch {
-                await MainActor.run {
-                    isExporting = false
-                    showError("Export failed: \(error.localizedDescription)")
-                }
-            }
-        }
-    }
-
-    private func clearBanners() {
-        bannerDismissTask?.cancel()
-        bannerDismissTask = nil
-        copyConfirmation = nil
-        exportErrorMessage = nil
-    }
-
-    private func showBanner(success: String) {
-        copyConfirmation = success
-        exportErrorMessage = nil
-        scheduleBannerDismiss()
-    }
-
-    private func showError(_ message: String) {
-        exportErrorMessage = message
-        copyConfirmation = nil
-        scheduleBannerDismiss()
-    }
-
-    private func scheduleBannerDismiss() {
-        bannerDismissTask?.cancel()
-        bannerDismissTask = Task { @MainActor in
-            try? await Task.sleep(for: Self.bannerVisibleDuration)
-            guard !Task.isCancelled else { return }
-            copyConfirmation = nil
-            exportErrorMessage = nil
-        }
-    }
-
-    private func writeStringToClipboard(_ string: String) {
-        #if os(iOS) || os(visionOS)
-        UIPasteboard.general.string = string
-        #elseif os(macOS)
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(string, forType: .string)
-        #endif
     }
 }

--- a/FHIR-HOSE/ViewModel/FHIRBundleExporter.swift
+++ b/FHIR-HOSE/ViewModel/FHIRBundleExporter.swift
@@ -5,21 +5,64 @@
 
 import Foundation
 
-/// Assembles every record's FHIR JSON into a single FHIR R4 `collection` Bundle,
-/// suitable for handing to downstream consumers that expect a Bundle envelope.
+/// Assembles records' FHIR JSON into one or more FHIR `collection` Bundles,
+/// bucketed by FHIR release so each output Bundle contains only one spec version.
 ///
-/// - Charmonizer-produced records contribute their `fhirData` (a Patient resource).
 /// - HealthKit-sourced records contribute the base64-encoded JSON stored under
-///   `healthKitData["fhirResource"]`. When that payload is itself a Bundle, its
-///   entries are flattened into the output Bundle.
+///   `healthKitData["fhirResource"]`; release comes from `healthKitData["fhirRelease"]`
+///   and the precise version string from `healthKitData["fhirVersion"]`.
+/// - When a HealthKit payload is itself a Bundle, its entries are flattened into the
+///   bucket for the wrapper's release.
+/// - Charmonizer-produced records (`fhirData`) carry no version metadata and land in
+///   the `"unknown"` bucket.
 enum FHIRBundleExporter {
 
-    static func makeCollectionBundle(from records: [HealthRecord]) -> [String: Any] {
+    /// A single per-release output ready to copy or write to disk.
+    struct Export {
+        /// `"dstu1"`, `"dstu2"`, `"stu3"`, `"r4"`, `"r4b"`, `"r5"`, or `"unknown"`.
+        let release: String
+        /// The assembled Bundle dictionary, with `meta.tag` entries for each precise
+        /// FHIR version observed in the source records.
+        let bundle: [String: Any]
+        /// Convenience count of entries in this bundle.
+        let entryCount: Int
+
+        /// Short FHIR release name shown in UI (e.g. `"R4"`, `"R4B"`, `"DSTU2"`).
+        var displayName: String {
+            switch release {
+            case "dstu1": return "DSTU1"
+            case "dstu2": return "DSTU2"
+            case "stu3":  return "STU3"
+            case "r4":    return "R4"
+            case "r4b":   return "R4B"
+            case "r5":    return "R5"
+            default:      return "Unknown"
+            }
+        }
+
+        func data(prettyPrinted: Bool = true) throws -> Data {
+            let options: JSONSerialization.WritingOptions = prettyPrinted
+                ? [.prettyPrinted, .sortedKeys]
+                : []
+            return try JSONSerialization.data(withJSONObject: bundle, options: options)
+        }
+    }
+
+    /// Per-release accumulator: the entries plus every distinct precise version
+    /// string observed (e.g. `"4.0.1"`, `"4.0.2"` within an R4 bucket).
+    private struct Bucket {
         var entries: [[String: Any]] = []
+        var versions: Set<String> = []
+    }
+
+    /// Returns one `Export` per FHIR release present in `records`, ordered newest-first.
+    /// Releases with zero entries are omitted.
+    static func makeExports(from records: [HealthRecord]) -> [Export] {
+        var buckets: [String: Bucket] = [:]
 
         for record in records {
             if let resource = record.fhirData {
-                appendResource(resource, to: &entries)
+                appendResource(resource, release: "unknown", version: nil, to: &buckets)
                 continue
             }
 
@@ -27,41 +70,70 @@ enum FHIRBundleExporter {
                !b64.isEmpty,
                let raw = Data(base64Encoded: b64),
                let resource = try? JSONSerialization.jsonObject(with: raw) as? [String: Any] {
-                appendResource(resource, to: &entries)
+                let release = (record.healthKitData?["fhirRelease"] as? String) ?? "unknown"
+                let version = record.healthKitData?["fhirVersion"] as? String
+                appendResource(resource, release: release, version: version, to: &buckets)
             }
         }
 
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime]
-
-        let bundle: [String: Any] = [
-            "resourceType": "Bundle",
-            "type": "collection",
-            "timestamp": iso.string(from: Date()),
-            "entry": entries
-        ]
-        return bundle
+        let order = ["r5", "r4b", "r4", "stu3", "dstu2", "dstu1", "unknown"]
+        return order.compactMap { release in
+            guard let bucket = buckets[release], !bucket.entries.isEmpty else { return nil }
+            return Export(
+                release: release,
+                bundle: makeBundle(release: release, bucket: bucket),
+                entryCount: bucket.entries.count
+            )
+        }
     }
 
-    static func makeCollectionBundleData(from records: [HealthRecord]) throws -> Data {
-        let bundle = makeCollectionBundle(from: records)
-        return try JSONSerialization.data(
-            withJSONObject: bundle,
-            options: [.prettyPrinted, .sortedKeys]
-        )
-    }
+    private static func appendResource(
+        _ resource: [String: Any],
+        release: String,
+        version: String?,
+        to buckets: inout [String: Bucket]
+    ) {
+        var bucket = buckets[release] ?? Bucket()
+        if let version, !version.isEmpty, version != "unknown" {
+            bucket.versions.insert(version)
+        }
 
-    private static func appendResource(_ resource: [String: Any], to entries: inout [[String: Any]]) {
         if (resource["resourceType"] as? String) == "Bundle",
            let inner = resource["entry"] as? [[String: Any]] {
             for innerEntry in inner {
                 if let innerResource = innerEntry["resource"] as? [String: Any] {
-                    entries.append(["resource": innerResource])
+                    bucket.entries.append(["resource": innerResource])
                 }
             }
-            return
+        } else {
+            bucket.entries.append(["resource": resource])
         }
 
-        entries.append(["resource": resource])
+        buckets[release] = bucket
+    }
+
+    private static func makeBundle(release: String, bucket: Bucket) -> [String: Any] {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+
+        var bundle: [String: Any] = [
+            "resourceType": "Bundle",
+            "type": "collection",
+            "timestamp": iso.string(from: Date()),
+            "entry": bucket.entries
+        ]
+
+        // Emit one meta.tag per distinct precise version observed in the source records.
+        // Spec-correct, machine-readable, and survives mixed patch versions within a release.
+        if !bucket.versions.isEmpty {
+            let tags: [[String: String]] = bucket.versions.sorted().map { version in
+                [
+                    "system": "http://hl7.org/fhir/FHIR-version",
+                    "code": version
+                ]
+            }
+            bundle["meta"] = ["tag": tags]
+        }
+        return bundle
     }
 }

--- a/FHIR-HOSE/ViewModel/FetchHealthKit.swift
+++ b/FHIR-HOSE/ViewModel/FetchHealthKit.swift
@@ -10,6 +10,24 @@ import Foundation
 
 private let fileLogger = FileLogger.shared
 
+/// Maps an `HKFHIRVersion` to a release code used for bucketing exports.
+///
+/// FHIR release lineage: DSTU1 (0.x), DSTU2 (1.0.x), STU3 (3.0.x), R4 (4.0.x),
+/// R4B (4.3.x), R5 (5.0.x). R4 and R4B share major version 4 and are distinguished
+/// by minor version. Versions not on this lineage fall through to `"unknown"`.
+private func fhirReleaseCode(for version: HKFHIRVersion?) -> String {
+    guard let v = version else { return "unknown" }
+    switch (v.majorVersion, v.minorVersion) {
+    case (0, _): return "dstu1"
+    case (1, _): return "dstu2"
+    case (3, _): return "stu3"
+    case (4, 0): return "r4"
+    case (4, 3): return "r4b"
+    case (5, _): return "r5"
+    default: return "unknown"
+    }
+}
+
 extension HKBloodType {
     var displayString: String {
         switch self {
@@ -350,7 +368,9 @@ class HealthKitManager: ObservableObject {
                         "displayName": sample.clinicalType.identifier,
                         "startDate": sample.startDate,
                         "endDate": sample.endDate,
-                        "fhirResource": sample.fhirResource?.data.base64EncodedString() ?? ""
+                        "fhirResource": sample.fhirResource?.data.base64EncodedString() ?? "",
+                        "fhirVersion": sample.fhirResource?.fhirVersion.stringRepresentation ?? "unknown",
+                        "fhirRelease": fhirReleaseCode(for: sample.fhirResource?.fhirVersion)
                     ]
                     
                     // Debug: Check if this clinical record contains Patient data
@@ -460,7 +480,9 @@ class HealthKitManager: ObservableObject {
                                     "startDate": sample.startDate,
                                     "endDate": sample.endDate,
                                     "sourceType": identifier.rawValue,
-                                    "fhirResource": try! JSONSerialization.data(withJSONObject: resource).base64EncodedString()
+                                    "fhirResource": try! JSONSerialization.data(withJSONObject: resource).base64EncodedString(),
+                                    "fhirVersion": fhirResource.fhirVersion.stringRepresentation,
+                                    "fhirRelease": fhirReleaseCode(for: fhirResource.fhirVersion)
                                 ]
                                 
                                 let patientRecord = HealthRecord(healthKitType: "PatientFHIRResource", data: patientData, date: sample.startDate)
@@ -480,7 +502,9 @@ class HealthKitManager: ObservableObject {
                             "startDate": sample.startDate,
                             "endDate": sample.endDate,
                             "sourceType": identifier.rawValue,
-                            "fhirResource": fhirResource.data.base64EncodedString()
+                            "fhirResource": fhirResource.data.base64EncodedString(),
+                            "fhirVersion": fhirResource.fhirVersion.stringRepresentation,
+                            "fhirRelease": fhirReleaseCode(for: fhirResource.fhirVersion)
                         ]
                         
                         let patientRecord = HealthRecord(healthKitType: "PatientFHIRResource", data: patientData, date: sample.startDate)

--- a/FHIR-HOSE/ViewModel/ZipEncoder.swift
+++ b/FHIR-HOSE/ViewModel/ZipEncoder.swift
@@ -1,0 +1,124 @@
+//
+//  ZipEncoder.swift
+//  FHIR-HOSE
+//
+
+import Foundation
+
+/// Produces a PKZIP "stored" (uncompressed) archive from a list of named in-memory files.
+/// The output is a standard `.zip` readable by Finder, `unzip`, the iOS Files app, etc.
+///
+/// Stored mode is used because the payloads here are small JSON files and avoiding
+/// compression keeps the implementation dependency-free (no zlib deflate stream wiring).
+enum ZipEncoder {
+
+    struct File {
+        let name: String
+        let data: Data
+    }
+
+    static func makeArchive(files: [File]) -> Data {
+        var output = Data()
+        var centralDirectory = Data()
+        let now = dosDateTime(Date())
+
+        for file in files {
+            let nameBytes = Array(file.name.utf8)
+            let size = UInt32(file.data.count)
+            let crc = crc32(file.data)
+            let localOffset = UInt32(output.count)
+
+            // Local file header
+            output.append(uint32: 0x04034b50)            // signature
+            output.append(uint16: 20)                    // version needed
+            output.append(uint16: 0)                     // general purpose bit flag
+            output.append(uint16: 0)                     // compression method (0 = stored)
+            output.append(uint16: now.time)
+            output.append(uint16: now.date)
+            output.append(uint32: crc)
+            output.append(uint32: size)                  // compressed size
+            output.append(uint32: size)                  // uncompressed size
+            output.append(uint16: UInt16(nameBytes.count))
+            output.append(uint16: 0)                     // extra field length
+            output.append(Data(nameBytes))
+            output.append(file.data)
+
+            // Central directory entry
+            centralDirectory.append(uint32: 0x02014b50)
+            centralDirectory.append(uint16: 20)          // version made by
+            centralDirectory.append(uint16: 20)          // version needed
+            centralDirectory.append(uint16: 0)
+            centralDirectory.append(uint16: 0)
+            centralDirectory.append(uint16: now.time)
+            centralDirectory.append(uint16: now.date)
+            centralDirectory.append(uint32: crc)
+            centralDirectory.append(uint32: size)
+            centralDirectory.append(uint32: size)
+            centralDirectory.append(uint16: UInt16(nameBytes.count))
+            centralDirectory.append(uint16: 0)           // extra
+            centralDirectory.append(uint16: 0)           // comment
+            centralDirectory.append(uint16: 0)           // disk number
+            centralDirectory.append(uint16: 0)           // internal attrs
+            centralDirectory.append(uint32: 0)           // external attrs
+            centralDirectory.append(uint32: localOffset)
+            centralDirectory.append(Data(nameBytes))
+        }
+
+        let centralDirOffset = UInt32(output.count)
+        output.append(centralDirectory)
+
+        // End of central directory record
+        output.append(uint32: 0x06054b50)
+        output.append(uint16: 0)                          // disk number
+        output.append(uint16: 0)                          // disk with central dir
+        output.append(uint16: UInt16(files.count))
+        output.append(uint16: UInt16(files.count))
+        output.append(uint32: UInt32(centralDirectory.count))
+        output.append(uint32: centralDirOffset)
+        output.append(uint16: 0)                          // comment length
+
+        return output
+    }
+
+    private static let crcTable: [UInt32] = (0..<256).map { i -> UInt32 in
+        var c = UInt32(i)
+        for _ in 0..<8 {
+            c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1
+        }
+        return c
+    }
+
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFFFFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = (crc >> 8) ^ crcTable[index]
+        }
+        return crc ^ 0xFFFFFFFF
+    }
+
+    private static func dosDateTime(_ date: Date) -> (date: UInt16, time: UInt16) {
+        let cal = Calendar(identifier: .gregorian)
+        let c = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        let year = UInt16(max(1980, c.year ?? 1980) - 1980)
+        let month = UInt16(c.month ?? 1)
+        let day = UInt16(c.day ?? 1)
+        let hour = UInt16(c.hour ?? 0)
+        let minute = UInt16(c.minute ?? 0)
+        let second = UInt16((c.second ?? 0) / 2)
+        let dosDate = (year << 9) | (month << 5) | day
+        let dosTime = (hour << 11) | (minute << 5) | second
+        return (dosDate, dosTime)
+    }
+}
+
+private extension Data {
+    mutating func append(uint16 value: UInt16) {
+        var v = value.littleEndian
+        Swift.withUnsafeBytes(of: &v) { append(contentsOf: $0) }
+    }
+    mutating func append(uint32 value: UInt32) {
+        var v = value.littleEndian
+        Swift.withUnsafeBytes(of: &v) { append(contentsOf: $0) }
+    }
+}


### PR DESCRIPTION
- Captures FHIR version metadata per HealthKit record and buckets exports by release, emitting a separate Bundle per version (each tagged with `meta.tag`). 
- Adds a pure-Swift uncompressed ZIP encoder so multi-release exports can be shared as one archive. 
- Replaces the top toolbar export icon with a full-width "Export Health Data" button anchored at the bottom of the Records tab; uses ShareLink + Transferable so one tap goes straight to the iOS share sheet.